### PR TITLE
fix: webhook service and controller tests

### DIFF
--- a/src/services/cryptoGenerator.service.ts
+++ b/src/services/cryptoGenerator.service.ts
@@ -1,0 +1,38 @@
+import crypto from 'crypto'
+import { WebhookPayload } from '../interfaces/webhook.interfaces';
+
+export class CryptoGeneratorService {
+
+    async generateSignatureForWebhookPayload(payload: WebhookPayload, secret: string): Promise<string> {
+        const nonce = await this.generateNonce()
+        const { timestamp } = payload
+        const timestampMs = Date.parse(timestamp);
+        const now = Date.now()
+
+        if (Math.abs(now - timestampMs) > 5 * 60 * 1000) {
+            throw new Error('Timestamp validation failed. Request too old or future dated')
+        }
+
+        const hmac = crypto.createHmac('sha256', secret);
+        payload.nonce = nonce
+
+        const dataToSign = {
+            ...payload, nonce, timestamp
+        }
+
+        hmac.update(JSON.stringify(dataToSign))
+        const signature = hmac.digest('hex')
+
+        if (payload.reqMethod === 'GET' || payload.reqMethod.startsWith('GET_')) {
+            const url = new URL(payload.metadata?.url);
+            url.searchParams.append('signature', signature)
+            return url.toString()
+        }
+
+        return signature
+    }
+
+    private async generateNonce (): Promise<string> {
+        return crypto.randomBytes(16).toString('hex');
+    }
+}

--- a/src/services/webhook.service.ts
+++ b/src/services/webhook.service.ts
@@ -1,52 +1,13 @@
-import axios from 'axios'
-import crypto from 'crypto'
-import { WebhookPayload, MerchantWebhook, Merchant } from '../interfaces/webhook.interfaces'
-import { validateWebhookUrl } from '../validators/webhook.validators'
-import { MerchantAuthService } from './merchant.service';
+import { MerchantWebhook } from '../interfaces/webhook.interfaces'
 import { Repository } from "typeorm";
 import AppDataSource from "../config/db";
 import { MerchantWebhookEntity } from './../entities/MerchantWebhook.entity';
-
-const merchantAuthService = new MerchantAuthService()
 
 export class WebhookService {
     private merchantWebhookrepository: Repository<MerchantWebhookEntity>
 
     constructor() {
         this.merchantWebhookrepository = AppDataSource.getRepository(MerchantWebhookEntity)
-    }
-
-    private async generateNonce (): Promise<string> {
-        return crypto.randomBytes(16).toString('hex');
-    }
-
-    private async generateSignature(payload: WebhookPayload, secret: string): Promise<string> {
-        const nonce = await this.generateNonce()
-        const { timestamp } = payload
-        const timestampMs = Date.parse(timestamp);
-        const now = Date.now()
-
-        if (Math.abs(now - timestampMs) > 5 * 60 * 1000) {
-            throw new Error('Timestamp validation failed. Request too old or future dated')
-        }
-
-        const hmac = crypto.createHmac('sha256', secret);
-        payload.nonce = nonce
-
-        const dataToSign = {
-            ...payload, nonce, timestamp
-        }
-
-        hmac.update(JSON.stringify(dataToSign))
-        const signature = hmac.digest('hex')
-
-        if (payload.reqMethod === 'GET' || payload.reqMethod.startsWith('GET_')) {
-            const url = new URL(payload.metadata?.url);
-            url.searchParams.append('signature', signature)
-            return url.toString()
-        }
-
-        return signature
     }
 
     async register (webhookdata: MerchantWebhook): Promise<MerchantWebhook> {
@@ -85,30 +46,6 @@ export class WebhookService {
         return savedUpdatedWebhook
     }
 
-    private async sendWebhookNotification(
-        webhookUrl: string,
-        payload: WebhookPayload,
-        id: string,
-    ): Promise<boolean> {
-        try {
-            const merchant: Merchant | null = await merchantAuthService.getMerchantById(id)
-            // if (!merchant) return
-            const signature = await this.generateSignature(payload, merchant?.secret!);
-            await axios.post(webhookUrl, payload, {
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-Webhook-Signature': signature
-                },
-                timeout: 5000
-            });
-
-            return true;
-        } catch (err) {
-            console.error('Failed to send webhook notification', err)
-            return false;
-        }
-    }
-
     async getMerchantWebhook(merchantId: string): Promise<MerchantWebhook | null> {
         try {
             const merchantWebhook = await this.merchantWebhookrepository.findOne({
@@ -127,41 +64,5 @@ export class WebhookService {
             console.error('Failed to get merchant webhook', err)
             return null
         }
-    }
-
-    private async notifyPaymentUpdate(
-        merchantWebhook: MerchantWebhook,
-        paymentDetails: Omit<WebhookPayload, 'timestamp'>
-    ): Promise<boolean> {
-        const merchant = await merchantAuthService.getMerchantById(merchantWebhook.merchantId)
-        if (!merchantWebhook.isActive || !validateWebhookUrl(merchantWebhook.url)) {
-            return false;
-        }
-
-        const webhookPayload: WebhookPayload = {
-            ...paymentDetails,
-            timestamp: new Date().toISOString()
-        }
-
-        return this.sendWebhookNotification(merchantWebhook.url, webhookPayload, merchant?.secret!)
-    }
-
-    async notifyWithRetry(merchantWebhook: MerchantWebhook, webhookPayload: WebhookPayload, maxRetries = 3, delay = 3000) {
-        let attempts = 0;
-
-        while (attempts < maxRetries) {
-            try {
-                await this.notifyPaymentUpdate(merchantWebhook, webhookPayload);
-                return; // Exit if successful
-            } catch (err) {
-                attempts++;
-                console.error(`Attempt ${attempts} failed:`, err);
-
-                if (attempts < maxRetries) {
-                    await new Promise(resolve => setTimeout(resolve, delay)); // Wait before retrying
-                }
-            }
-        }
-        console.error("Failed to notify after maximum retries.");
     }
 }

--- a/src/services/webhookNotification.service.ts
+++ b/src/services/webhookNotification.service.ts
@@ -1,0 +1,77 @@
+import axios from 'axios'
+import { WebhookPayload, MerchantWebhook, Merchant } from '../interfaces/webhook.interfaces'
+import { validateWebhookUrl } from '../validators/webhook.validators'
+import { MerchantAuthService } from './merchant.service';
+import { CryptoGeneratorService } from './cryptoGenerator.service';
+
+const defaultMerchantAuthService = new MerchantAuthService()
+const defaultCryptoGeneratorService = new CryptoGeneratorService()
+export class WebhookNotificationService {
+    private merchantAuthService: MerchantAuthService
+    private cryptoGeneratorService: CryptoGeneratorService
+
+    constructor(merchantAuthService?: MerchantAuthService, criptoGeneratorService?: CryptoGeneratorService) {
+        this.merchantAuthService = merchantAuthService ?? defaultMerchantAuthService
+        this.cryptoGeneratorService = criptoGeneratorService ?? defaultCryptoGeneratorService
+    }
+
+    async sendWebhookNotification(
+        webhookUrl: string,
+        payload: WebhookPayload,
+        id: string,
+    ): Promise<boolean> {
+        try {
+            const merchant: Merchant | null = await this.merchantAuthService.getMerchantById(id)
+            // if (!merchant) return
+            const signature = await this.cryptoGeneratorService.generateSignatureForWebhookPayload(payload, merchant?.secret!);
+            await axios.post(webhookUrl, payload, {
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Webhook-Signature': signature
+                },
+                timeout: 5000
+            });
+
+            return true;
+        } catch (err) {
+            console.error('Failed to send webhook notification', err)
+            return false;
+        }
+    }
+
+    async notifyPaymentUpdate(
+        merchantWebhook: MerchantWebhook,
+        paymentDetails: Omit<WebhookPayload, 'timestamp'>
+    ): Promise<boolean> {
+        const merchant = await this.merchantAuthService.getMerchantById(merchantWebhook.merchantId)
+        if (!merchantWebhook.isActive || !validateWebhookUrl(merchantWebhook.url)) {
+            return false;
+        }
+
+        const webhookPayload: WebhookPayload = {
+            ...paymentDetails,
+            timestamp: new Date().toISOString()
+        }
+
+        return this.sendWebhookNotification(merchantWebhook.url, webhookPayload, merchant?.secret!)
+    }
+
+    async notifyWithRetry(merchantWebhook: MerchantWebhook, webhookPayload: WebhookPayload, maxRetries = 3, delay = 3000) {
+        let attempts = 0;
+
+        while (attempts < maxRetries) {
+            try {
+                await this.notifyPaymentUpdate(merchantWebhook, webhookPayload);
+                return; // Exit if successful
+            } catch (err) {
+                attempts++;
+                console.error(`Attempt ${attempts} failed:`, err);
+
+                if (attempts < maxRetries) {
+                    await new Promise(resolve => setTimeout(resolve, delay)); // Wait before retrying
+                }
+            }
+        }
+        console.error("Failed to notify after maximum retries.");
+    }
+}

--- a/src/tests/services/cryptoGenerator.service.test.ts
+++ b/src/tests/services/cryptoGenerator.service.test.ts
@@ -1,0 +1,49 @@
+import crypto from 'crypto';
+import { WebhookPayload } from '../../interfaces/webhook.interfaces';
+import { CryptoGeneratorService } from '../../services/cryptoGenerator.service';
+
+jest.mock('crypto');
+jest.spyOn(crypto, 'randomBytes').mockImplementation((size: number) => {
+    return Buffer.from(Array.from({ length: size }, () => Math.floor(Math.random() * 256)));
+});
+
+describe('CryptoGeneratorService', () => {
+    let cryptoGeneratorService: CryptoGeneratorService;
+
+    beforeEach(() => {
+        cryptoGeneratorService = new CryptoGeneratorService();
+        jest.clearAllMocks();
+    });
+
+    const mockWebhookPayload: WebhookPayload = {
+        transactionId: 'txn123',
+        transactionType: 'deposit',
+        status: 'completed',
+        amount: '100.00',
+        asset: 'USDC',
+        merchantId: 'merchant123',
+        timestamp: new Date().toISOString(),
+        eventType: 'payment.success',
+        reqMethod: 'POST'
+    };
+
+    const secret = 'test-secret'
+
+    describe('generateSignature', () => {
+        it('should generate a valid HMAC signature', async () => {
+            const mockHmac = {
+                update: jest.fn().mockReturnThis(),
+                digest: jest.fn().mockReturnValue('mock-signature')
+            };
+
+            (crypto.createHmac as jest.Mock).mockReturnValue(mockHmac);
+
+            const signature = await cryptoGeneratorService.generateSignatureForWebhookPayload(mockWebhookPayload, secret);
+
+            expect(crypto.createHmac).toHaveBeenCalledWith('sha256', secret);
+            expect(mockHmac.update).toHaveBeenCalledWith(JSON.stringify(mockWebhookPayload));
+            expect(mockHmac.digest).toHaveBeenCalledWith('hex');
+            expect(signature).toBe('mock-signature');
+        });
+    });
+});

--- a/src/tests/services/webhook.service.test.ts
+++ b/src/tests/services/webhook.service.test.ts
@@ -1,26 +1,16 @@
 import axios from 'axios';
 import crypto from 'crypto';
 import { WebhookService } from '../../services/webhook.service';
-import { MerchantAuthService } from '../../services/merchant.service';
 import { WebhookPayload, MerchantWebhook, Merchant } from '../../interfaces/webhook.interfaces';
 import { validateWebhookUrl } from '../../validators/webhook.validators';
-import { MerchantWebhookEntity } from 'src/entities/MerchantWebhook.entity';
 
-jest.mock('axios');
-jest.mock('crypto');
-jest.mock('../../services/merchant.service');
-jest.mock('../../validators/webhook.validators');
-jest.spyOn(crypto, 'randomBytes').mockImplementation((size: number) => {
-    return Buffer.from(Array.from({ length: size }, () => Math.floor(Math.random() * 256)));
-});
+
 
 describe('WebhookService', () => {
     let webhookService: WebhookService;
-    let merchantAuthService: MerchantAuthService;
 
     beforeEach(() => {
         webhookService = new WebhookService();
-        merchantAuthService = new MerchantAuthService();
         jest.clearAllMocks();
     });
 
@@ -56,74 +46,6 @@ describe('WebhookService', () => {
         updatedAt: new Date()
     };
 
-    describe('generateSignature', () => {
-        it('should generate a valid HMAC signature', async () => {
-            const mockHmac = {
-                update: jest.fn().mockReturnThis(),
-                digest: jest.fn().mockReturnValue('mock-signature')
-            };
-
-            (crypto.createHmac as jest.Mock).mockReturnValue(mockHmac);
-
-            const signature = await (webhookService as any).generateSignature(mockWebhookPayload, mockMerchant.secret);
-
-            expect(crypto.createHmac).toHaveBeenCalledWith('sha256', mockMerchant.secret);
-            expect(mockHmac.update).toHaveBeenCalledWith(JSON.stringify(mockWebhookPayload));
-            expect(mockHmac.digest).toHaveBeenCalledWith('hex');
-            expect(signature).toBe('mock-signature');
-        });
-    });
-
-    describe('sendWebhookNotification', () => {
-        it('should send a webhook notification successfully', async () => {
-            (merchantAuthService.getMerchantById as jest.Mock).mockResolvedValue(mockMerchant);
-
-            const mockHmac = {
-                update: jest.fn().mockReturnThis(),
-                digest: jest.fn().mockReturnValue('mock-signature')
-            };
-
-            (crypto.createHmac as jest.Mock).mockReturnValue(mockHmac);
-            (axios.post as jest.Mock).mockResolvedValue({ status: 200 });
-
-            const result = await (webhookService as any).sendWebhookNotification(
-                mockMerchantWebhook.url,
-                mockWebhookPayload,
-                mockMerchant.id
-            );
-
-            expect(axios.post).toHaveBeenCalledWith(mockMerchantWebhook.url, mockWebhookPayload, {
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-Webhook-Signature': 'mock-signature'
-                },
-                timeout: 5000
-            });
-            expect(result).toBe(true);
-        });
-
-        it('should return false if webhook notification fails', async () => {
-            (merchantAuthService.getMerchantById as jest.Mock).mockResolvedValue(mockMerchant);
-
-            const mockHmac = {
-                update: jest.fn().mockReturnThis(),
-                digest: jest.fn().mockReturnValue('mock-signature')
-            };
-
-            (crypto.createHmac as jest.Mock).mockReturnValue(mockHmac);
-            (axios.post as jest.Mock).mockRejectedValue(new Error('Network error'));
-
-            const result = await (webhookService as any).sendWebhookNotification(
-                mockMerchantWebhook.url,
-                mockWebhookPayload,
-                mockMerchant.id
-            );
-
-            expect(axios.post).toHaveBeenCalled();
-            expect(result).toBe(false);
-        });
-    });
-
     describe('getMerchantWebhook', () => {
         it('should return a merchant webhook if it is active', async () => {
             jest.spyOn(webhookService, 'getMerchantWebhook').mockResolvedValue(mockMerchantWebhook);
@@ -145,58 +67,6 @@ describe('WebhookService', () => {
             await expect(webhookService.getMerchantWebhook(mockMerchant.id)).rejects.toThrow(
                 'Merchant web hook not found'
             );
-        });
-    });
-
-    describe('notifyPaymentUpdate', () => {
-        it('should send a webhook notification when merchant and webhook are valid', async () => {
-            (merchantAuthService.getMerchantById as jest.Mock).mockResolvedValue(mockMerchant);
-            (validateWebhookUrl as jest.Mock).mockReturnValue(true);
-            (webhookService as any).sendWebhookNotification = jest.fn().mockResolvedValue(true);
-
-            const result = await (webhookService as any).notifyPaymentUpdate(mockMerchantWebhook, mockWebhookPayload);
-
-            expect(validateWebhookUrl).toHaveBeenCalledWith(mockMerchantWebhook.url);
-            expect(result).toBe(true);
-        });
-
-        it('should return false if webhook URL is invalid', async () => {
-            (validateWebhookUrl as jest.Mock).mockReturnValue(false);
-
-            const result = await (webhookService as any).notifyPaymentUpdate(mockMerchantWebhook, mockWebhookPayload);
-
-            expect(result).toBe(false);
-        });
-    });
-
-    describe('notifyWithRetry', () => {
-        it('should retry sending webhook notification up to maxRetries', async () => {
-            jest.spyOn(global, 'setTimeout').mockImplementation((fn, ms) => {
-                fn(); // Execute the callback immediately
-                return {} as unknown as NodeJS.Timeout; // Return a mocked timeout object
-            });
-
-            (webhookService as any).notifyPaymentUpdate = jest
-                .fn()
-                .mockRejectedValueOnce(new Error('Network Error'))
-                .mockResolvedValue(true);
-
-            await webhookService.notifyWithRetry(mockMerchantWebhook, mockWebhookPayload, 3, 1000);
-
-            expect((webhookService as any).notifyPaymentUpdate).toHaveBeenCalledTimes(2);
-        });
-
-        it('should fail after max retries', async () => {
-            jest.spyOn(global, 'setTimeout').mockImplementation((fn, ms) => {
-                fn(); // Execute the callback immediately
-                return {} as unknown as NodeJS.Timeout; // Return a mocked timeout object
-            });
-
-            (webhookService as any).notifyPaymentUpdate = jest.fn().mockRejectedValue(new Error('Network Error'));
-
-            await webhookService.notifyWithRetry(mockMerchantWebhook, mockWebhookPayload, 3, 1000);
-
-            expect((webhookService as any).notifyPaymentUpdate).toHaveBeenCalledTimes(3);
         });
     });
 });

--- a/src/tests/services/webhookNotification.service.test.ts
+++ b/src/tests/services/webhookNotification.service.test.ts
@@ -1,0 +1,162 @@
+import axios from 'axios';
+import crypto from 'crypto';
+import { MerchantAuthService } from '../../services/merchant.service';
+import { WebhookPayload, MerchantWebhook, Merchant } from '../../interfaces/webhook.interfaces';
+import { validateWebhookUrl } from '../../validators/webhook.validators';
+import { CryptoGeneratorService } from '../../services/cryptoGenerator.service';
+import { WebhookNotificationService } from '../../services/webhookNotification.service';
+
+jest.mock('axios');
+jest.mock('crypto');
+jest.mock('../../services/merchant.service');
+jest.mock('../../validators/webhook.validators');
+jest.spyOn(crypto, 'randomBytes').mockImplementation((size: number) => {
+    return Buffer.from(Array.from({ length: size }, () => Math.floor(Math.random() * 256)));
+});
+
+describe('WebhookNotificationService', () => {
+    let webhookNotificationService: WebhookNotificationService;
+    let merchantAuthService: MerchantAuthService;
+    let cryptoGeneratorService: CryptoGeneratorService;
+
+    beforeEach(() => {
+        merchantAuthService = new MerchantAuthService();
+        cryptoGeneratorService = new CryptoGeneratorService()
+        webhookNotificationService = new WebhookNotificationService(merchantAuthService, cryptoGeneratorService);
+        jest.clearAllMocks();
+    });
+
+    const mockMerchant: Merchant = {
+        id: 'merchant123',
+        apiKey: 'test-api-key',
+        secret: 'test-secret',
+        name: 'Test Merchant',
+        email: 'merchant@test.com',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date()
+    };
+
+    const mockWebhookPayload: WebhookPayload = {
+        transactionId: 'txn123',
+        transactionType: 'deposit',
+        status: 'completed',
+        amount: '100.00',
+        asset: 'USDC',
+        merchantId: 'merchant123',
+        timestamp: new Date().toISOString(),
+        eventType: 'payment.success',
+        reqMethod: 'POST'
+    };
+
+    const mockMerchantWebhook: MerchantWebhook = {
+        id: 'webhook123',
+        merchantId: 'merchant123',
+        url: 'https://example.com/webhook',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date()
+    };
+
+    describe('sendWebhookNotification', () => {
+        it('should send a webhook notification successfully', async () => {
+            (merchantAuthService.getMerchantById as jest.Mock).mockResolvedValue(mockMerchant);
+
+            const mockHmac = {
+                update: jest.fn().mockReturnThis(),
+                digest: jest.fn().mockReturnValue('mock-signature')
+            };
+
+            (crypto.createHmac as jest.Mock).mockReturnValue(mockHmac);
+            (axios.post as jest.Mock).mockResolvedValue({ status: 200 });
+
+            const result = await webhookNotificationService.sendWebhookNotification(
+                mockMerchantWebhook.url,
+                mockWebhookPayload,
+                mockMerchant.id
+            );
+
+            expect(axios.post).toHaveBeenCalledWith(mockMerchantWebhook.url, mockWebhookPayload, {
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Webhook-Signature': 'mock-signature'
+                },
+                timeout: 5000
+            });
+            expect(result).toBe(true);
+        });
+
+        it('should return false if webhook notification fails', async () => {
+            (merchantAuthService.getMerchantById as jest.Mock).mockResolvedValue(mockMerchant);
+
+            const mockHmac = {
+                update: jest.fn().mockReturnThis(),
+                digest: jest.fn().mockReturnValue('mock-signature')
+            };
+
+            (crypto.createHmac as jest.Mock).mockReturnValue(mockHmac);
+            (axios.post as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+            const result = await webhookNotificationService.sendWebhookNotification(
+                mockMerchantWebhook.url,
+                mockWebhookPayload,
+                mockMerchant.id
+            );
+
+            expect(axios.post).toHaveBeenCalled();
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('notifyPaymentUpdate', () => {
+        it('should send a webhook notification when merchant and webhook are valid', async () => {
+            (merchantAuthService.getMerchantById as jest.Mock).mockResolvedValue(mockMerchant);
+            (validateWebhookUrl as jest.Mock).mockReturnValue(true);
+            webhookNotificationService.sendWebhookNotification = jest.fn().mockResolvedValue(true);
+
+            const result = await webhookNotificationService.notifyPaymentUpdate(mockMerchantWebhook, mockWebhookPayload);
+
+            expect(validateWebhookUrl).toHaveBeenCalledWith(mockMerchantWebhook.url);
+            expect(result).toBe(true);
+        });
+
+        it('should return false if webhook URL is invalid', async () => {
+            (validateWebhookUrl as jest.Mock).mockReturnValue(false);
+
+            const result = await webhookNotificationService.notifyPaymentUpdate(mockMerchantWebhook, mockWebhookPayload);
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('notifyWithRetry', () => {
+        it('should retry sending webhook notification up to maxRetries', async () => {
+            jest.spyOn(global, 'setTimeout').mockImplementation((fn, ms) => {
+                fn(); // Execute the callback immediately
+                return {} as unknown as NodeJS.Timeout; // Return a mocked timeout object
+            });
+
+            webhookNotificationService.notifyPaymentUpdate = jest
+                .fn()
+                .mockRejectedValueOnce(new Error('Network Error'))
+                .mockResolvedValue(true);
+
+            await webhookNotificationService.notifyWithRetry(mockMerchantWebhook, mockWebhookPayload, 3, 1000);
+
+            expect(webhookNotificationService.notifyPaymentUpdate).toHaveBeenCalledTimes(2);
+        });
+
+        it('should fail after max retries', async () => {
+            jest.spyOn(global, 'setTimeout').mockImplementation((fn, ms) => {
+                fn(); // Execute the callback immediately
+                return {} as unknown as NodeJS.Timeout; // Return a mocked timeout object
+            });
+
+            webhookNotificationService.notifyPaymentUpdate = jest.fn().mockRejectedValue(new Error('Network Error'));
+
+            await webhookNotificationService.notifyWithRetry(mockMerchantWebhook, mockWebhookPayload, 3, 1000);
+
+            expect(webhookNotificationService.notifyPaymentUpdate).toHaveBeenCalledTimes(3);
+        });
+    });
+});


### PR DESCRIPTION
# Pull Request Overview

## 📝 Summary
This PR fixes tests for `webhook.service.test.ts` and `webhook.controller.test.ts`

### 🔗 Related Issues
- Closes [#(issue number) Replace with the actual issue number](https://github.com/PayStell/paystell-backend/issues/32).

## 🔄 Changes Made

- Added a constructor to WebhookController to inject test mocks.
- Fixed mocks and tests for  `webhook.service.test.ts` and `webhook.controller.test.ts` files

## 🖼️ Current Output
N/A.

## 🧪 Testing

- Run `npm test -- webhook.controller`
- Run `npm test -- webhook.service`

## 💬 Comments
This PR only addresses those 2 failing test files.
The main reason is that the rest of the acceptance criteria of the issue is not very clear.

I also have some suggestions:

-  I strongly suggest implementing a dependency injection in the whole app. In my experience not having this will only cause headaches when setting mocks in the test suite and will also hurt the maintainability of the project long term.
- While looking at some of the tests I saw things like this: `await (**webhookService as any**).sendWebhookNotification(...` I noticed that `sendWebhookNotification` is a private method, testing private methods is bad practice, so I'd recommend abstracting private methods into another class, or test the private method through a public one.
- Is there a linter configured? if not, I think it would be a good first issue for someone, not having a linter is such a pain to maintain readability of the code long term.

let me know what you think.