### PR TITLE
implement webhook

### DIFF
--- a/src/entities/webLog.entity.ts
+++ b/src/entities/webLog.entity.ts
@@ -1,0 +1,40 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity()
+export class WebhookLog {
+  static createQueryBuilder(arg0: string) {
+    throw new Error("Method not implemented.");
+  }
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  merchantId: string;
+
+  @Column()
+  webhookUrl: string;
+
+  @Column({ type: 'enum', enum: ['success', 'failed'] })
+  status: 'success' | 'failed';
+
+  @Column('json')
+  payload: any; // or WebhookPayload interface
+
+  @Column('json', { nullable: true })
+  response?: any;
+
+  @Column({ nullable: true })
+  statusCode?: number;
+
+  @Column({ nullable: true })
+  errorMessage?: string;
+
+  @Column({ default: 0 })
+  retryCount: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/routes/webhook.routes.ts
+++ b/src/routes/webhook.routes.ts
@@ -29,5 +29,9 @@ router.post(
   authenticateStellarWebhook,
   asyncHandler(webhookController.handleWebhook),
 );
+router
+.get("/webhook/logs",
+  authenticateStellarWebhook, 
+  asyncHandler(webhookController.getWebhookLogs),);
 
 export default router;


### PR DESCRIPTION
📝 Summary
This PR implements webhook logging functionality. It records webhook delivery attempts (both successes and failures) into a WebhookLog entity, integrates it into the MerchantWebhookQueueService, and adds an endpoint to query these logs with filters.

🔗 Related Issues
Closes # (68)

🔄 Changes Made
Created a new WebhookLog entity with fields like merchantId, webhookUrl, status, payload, response, statusCode, errorMessage, retryCount, createdAt, and updatedAt.

Integrated webhook logging into MerchantWebhookQueueService:

On success: logs successful webhook deliveries.

On failure: logs failed deliveries with error details.

Created getWebhookLogs endpoint to:

Filter by status, merchantId, startDate, and endDate.

Added the /webhook/logs route protected by authenticateStellarWebhook middleware.

🖼️ Current Output
Successfully started the app and also tested  webhook logs for each delivery attempt in the database.
![Screenshot (590)](https://github.com/user-attachments/assets/c585d839-1c92-4a5b-b00e-b90dc219898f)



Example API Request:

bash
Copy
Edit
GET /webhook/logs?status=success&merchantId=abc123&startDate=2024-01-01&endDate=2024-01-31
Example JSON Response:

json
Copy
Edit
{
  "status": "success",
  "data": [
    {
      "id": "uuid",
      "merchantId": "abc123",
      "webhookUrl": "https://example.com/webhook",
      "status": "success",
      "payload": { ... },
      "response": null,
      "statusCode": 200,
      "retryCount": 1,
      "createdAt": "2025-04-26T12:00:00.000Z",
      "updatedAt": "2025-04-26T12:00:00.000Z"
    }
  ]
}
🧪 Testing
Verified webhook logs are created on both success and failure inside MerchantWebhookQueueService.

Tested getWebhookLogs endpoint manually using Postman with different combinations of query parameters.

Confirmed logs are correctly filtered by status, merchantId, and date range.



